### PR TITLE
Mock ATs (issue #6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,5 @@ script:
   - cd simple-mock-api-1
   - sh fetch_wiremock.sh
   - sh start.sh &
-  - cd ..
+  - cd ../acceptance
   - sh cuke.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,10 @@ script:
   - cd acceptance
   - bundle install
   - sh cuke.sh
+  - echo "Use mock for testing"
+  - docker-compose stop app1
+  - cd simple-mock-api-1
+  - sh fetch_wiremock.sh
+  - sh start.sh &
+  - cd ..
+  - sh cuke.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,5 +19,6 @@ script:
   - cd simple-mock-api-1
   - sh fetch_wiremock.sh
   - sh start.sh &
+  - sleep 5 && curl 'http://localhost:3000/api'
   - cd ../acceptance
   - sh cuke.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ script:
   - sh cuke.sh
   - echo "Use mock for testing"
   - docker-compose stop app1
+  - cd ..
   - cd simple-mock-api-1
   - sh fetch_wiremock.sh
   - sh start.sh &


### PR DESCRIPTION
Use simple mock to run ATs

This is a mainly CI task to provide an execution with mocked `app1` service instead of provided app1 implementation